### PR TITLE
Not drawing admin settings before discord authorization

### DIFF
--- a/src/routes/admin/characters.svelte
+++ b/src/routes/admin/characters.svelte
@@ -82,8 +82,10 @@
 					getCharacters();
 				}
 			}
+			if (user?.admin == true){
+				authorised = true;
+			}
 		});
-		authorised = true;
 	});
 
 	onDestroy(() => {

--- a/src/routes/admin/index.svelte
+++ b/src/routes/admin/index.svelte
@@ -24,8 +24,10 @@
 			if (user && !user.admin) {
 				goto('/');
 			}
+			if (user?.admin == true){
+				authorised = true;
+			}
 		});
-		authorised = true;
 	});
 
 	onDestroy(() => {

--- a/src/routes/admin/index.svelte
+++ b/src/routes/admin/index.svelte
@@ -10,6 +10,7 @@
 	import axios from 'axios';
 
 	let subscription: Unsubscriber | null = null;
+	let authorised: Boolean = false
 
 	onMount(async () => {
 		const result = await axios.get('/api/discord/authenticated');
@@ -24,6 +25,7 @@
 				goto('/');
 			}
 		});
+		authorised = true;
 	});
 
 	onDestroy(() => {
@@ -33,17 +35,23 @@
 	});
 </script>
 
+
 <div id="column">
 	<div id="content">
 		<div id="title">
 			<PageTitle string="admin.title" />
 		</div>
+		{#if !authorised }
+			<h2 class="s-O1LqmXjLTMeC">You are not Authorised</h2>
+		{/if}
 		<div id="buttons">
-			<AdminButton
-				onClick={() => goto('/admin/characters')}
-				title="admin.buttons.characters.title"
-				description="admin.buttons.characters.description"
-			/>
+			{#if authorised }
+				<AdminButton
+					onClick={() => goto('/admin/characters')}
+					title="admin.buttons.characters.title"
+					description="admin.buttons.characters.description"
+				/>
+			{/if}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Make so the admin settings don't show up before the user is authorized from the discord API.

Admin Settings can be currently seen with blocking the requests to the API.