### PR TITLE
filter for discorid and discord#

### DIFF
--- a/src/routes/api/collabs/[id]/picks/index.ts
+++ b/src/routes/api/collabs/[id]/picks/index.ts
@@ -94,6 +94,16 @@ export const get: RequestHandler = async ({ params, request }) => {
 				AND: search.map((s) => ({
 					character: { anime_name: { contains: s, mode: 'insensitive' } }
 				}))
+			},
+			{
+				AND: search.map((s) => ({
+					User: { username: { contains: s, mode: 'insensitive' } }
+				}))
+			},
+			{
+				AND: search.map((s) => ({
+					User: { discordId: { contains: s, mode: 'insensitive' } }
+				}))
 			}
 		];
 	}


### PR DESCRIPTION
closes #41

allows users to search for a discordid or hashtag mainly for staff for reports i suppose was asked for in staff chat just did it rlly quick.